### PR TITLE
gh-507 add product setup

### DIFF
--- a/_layouts/layout-product.html
+++ b/_layouts/layout-product.html
@@ -1,0 +1,35 @@
+{% assign sorted_use_cases = site.use_cases | sort:"order" %}
+
+{% include head.html %}
+
+<body class="{{page.bodyclass}}">
+
+    {% include organism-header.html %}
+
+    <main>
+        <article>
+            <div class="container">
+                <div class="wrapper--wide article__top">
+                    <div class="article__top-image-container">
+                        {% include article-image.html %}
+                    </div>
+                    <div class="article__top-content">
+                        <div class="article-intro">
+                            <!-- space-header-page -->
+                            {% include article-intro.html %}
+                        </div>
+                    </div>
+                </div>
+                <div class="wrapper">
+                    <section itemscope itemtype="http://schema.org/articleBody">
+                        <div class="article">
+                            {{ content }}
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </article>
+    </main>
+
+    {% include organism-footer.html %}
+ No newline at end of file

--- a/products/example/index.html.md
+++ b/products/example/index.html.md
@@ -1,0 +1,19 @@
+---
+bodyclass: ["page--products", " ", "page--products-index"]
+layout: layout-product
+title: Discover our Example
+description: Weaviate products and knowledge network offerings
+og-img: products.jpg
+image: /img/illustrations/HealthCareLifeSciences.svg
+imageCard: /img/decoration/use-case-healthcare@2x.jpg
+imageMobile: /img/decoration/use-case-1.jpg
+imageAlt: Knowledge graph to find new biologically active materials
+---
+
+## This a h2
+
+Foobar text
+
+<div class="container">
+  <h2>But also HTML is possible</h2>
+</div>

--- a/products/index.html
+++ b/products/index.html
@@ -26,30 +26,14 @@ og-img: products.jpg
                 {% endcapture %}
 
                 {% include components/card/card.html
-                    title="Weaviate"
+                    title="Example"
                     themeClass="card-white card--pilar card--theme-weaviate"
                     imgUrl="/img/logo-weaviate-emblem-color.svg"
-                    imgAlt="Weaviate for the logo"
-                    linkUrl="/products/weaviate/"
+                    imgAlt="To Be Defined"
+                    linkUrl="/products/example/"
                     linkExternal=false
-                    ctaText="Click to learn more about Weaviate Enterprise"
+                    ctaText="Click to learn more about Example"
                     content=carOneContent
-                %}
-                {% capture carTwoContent %}
-                    <div class="card__intro">
-                        <p><b>P2P networks based on Weaviate to securely share data and knowledge between organizations.</b></p>
-                    </div>
-                {% endcapture %}
-
-                {% include components/card/card.html
-                    title="Knowledge Networks"
-                    themeClass="card-white card--pilar card--theme-weaviate"
-                    imgUrl="/img/logo-icon-weaviate-network.svg"
-                    imgAlt="Knowledge Network logo"
-                    linkUrl="/newsletter"
-                    linkExternal=false
-                    ctaText="Soon to be released, click to stay in the know"
-                    content=carTwoContent
                 %}
                 
             </ul>


### PR DESCRIPTION
@bobvanluijt. Content changes required in:

Change the folder name `./products/<example>` into something more meaningful. 

**`./products/<example>/index.html.md`**
- [ ] Bodycopy goes into the main body oif this file
- [ ] main page illustration in 'image'
- [ ] mobile version of the main page illustration in 'imageMobile'
- [ ] smaller version (@2x) for the card image on the product overview page in 'imageCard'
- [ ] image for search engines: in 'og-img'

**Other:**
- [ ] Change the product card info in `./products/index.html`, and use as a card for the corresponding products.

- [ ] Remove the folder `./products/weaviate/**`.

- [ ] Use ./products/weaviate.html to  redirect visitors to other Weaviate page, or remove file entirely