### PR TITLE
Add hiring content for Core Engineers

### DIFF
--- a/_jobs/core-engineer.html.md
+++ b/_jobs/core-engineer.html.md
@@ -20,11 +20,21 @@ We enable our customers and open source community users to understand their data
 
 ## What We Are Looking For
 
-...
+Weaviate is the basis to how we provide value to our customers. This means Weaviate has to be fast, reliable, scalable and easy-to-use. We aim to provide value to our internal teams, external partners and clients in a fast and efficient manner - without ever sacrificing quality. For these challenges, we are looking for engineers who are able to work independently, take ownership of a topic and are motivated to lead, learn and grow. Weaviate Core Engineers typically have the following traits:
+
+1. Have experience in **Golang** (or similar strongly typed languages)
+1. Have a desire to write high-quality code with great test coverage (preferably TDD)
+1. Are great communicators and team-players
+1. Aim for short feedback cycles, efficient communication and take ownership of their work 
+1. Know what it means to run and maintain applications in production
+1. Show a cloud-native mindset (preferably experience with Docker & Kubernetes)
+1. Have experience with developing and using distributed systems and the trade-offs involved
 
 ## What You Will Be Working On
 
-...
+1. Add new features to Weaviate Core
+1. Help make Weaviate the best Vector Search Engine out there
+
 
 ## How We Work
 


### PR DESCRIPTION
I prefaced the list with 

> Weaviate Core Engineers typically have the following traits:

This is meant to indicate that the points on the list are not hard requirements, but "the more the better". For example, if someone would tick all boxes, but has never written a single line of Golang, this would not be an issue. Does that come across?